### PR TITLE
OnlineEMGRegressor Shared Memory Additions

### DIFF
--- a/libemg/_gui/_data_collection_panel.py
+++ b/libemg/_gui/_data_collection_panel.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import dearpygui.dearpygui as dpg
 import numpy as np
 import os
@@ -149,7 +150,7 @@ class DataCollectionPanel:
             for class_index, motion_class in enumerate(files):
                 # entry for collection of rep
                 media = Media()
-                media.from_file(self.media_folder + motion_class)
+                media.from_file(Path(self.media_folder, motion_class).absolute().as_posix())
                 collection_conf.append([media,motion_class.split('.')[0],class_index,rep_index,self.rep_time])
         return collection_conf
 
@@ -205,7 +206,8 @@ class DataCollectionPanel:
             
             self.play_collection_visual(media_list[self.i], active=True)
             
-            self.save_data(self.output_folder + "C_" + str(media_list[self.i][2]) + "_R_" + str(media_list[self.i][3]) + ".csv")
+            output_path = Path(self.output_folder, "C_" + str(media_list[self.i][2]) + "_R_" + str(media_list[self.i][3]) + ".csv").absolute().as_posix()
+            self.save_data(output_path)
             last_rep = media_list[self.i][3]
             self.i = self.i+1
             if self.i  == len(media_list):

--- a/libemg/_gui/_data_collection_panel.py
+++ b/libemg/_gui/_data_collection_panel.py
@@ -142,7 +142,7 @@ class DataCollectionPanel:
         collection_details["time"]    = datetime.now().isoformat()
         if not os.path.exists(self.output_folder):
             os.makedirs(self.output_folder)
-        with open(self.output_folder + "collection_details.json", 'w') as f:
+        with open(Path(self.output_folder, "collection_details.json").absolute().as_posix(), 'w') as f:
             json.dump(collection_details, f)
 
         # make the media list for SGT progression

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -1003,5 +1003,5 @@ class OnlineDataHandler(DataHandler):
                 return False
             
     def start_listening(self):
-        print("LibEMG>v1.0 no longer requires offline_data_handler.start_listening().\nThis is deprecated.")
+        print("LibEMG>v1.0 no longer requires online_data_handler.start_listening().\nThis is deprecated.")
         pass

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -741,7 +741,8 @@ class OnlineDataHandler(DataHandler):
             emg_plots.append(ax.plot([],[],label="CH"+str(channels[i])))
 
         def update(frame):
-            data = self.smm.get_variable("emg")
+            data, _ = self.get_data()
+            data = data['emg']
             data = data[:,channels]
             inter_channel_amount = 1.5 * np.max(data)
             if len(data) > num_samples:
@@ -784,7 +785,8 @@ class OnlineDataHandler(DataHandler):
             feature_list = ['MAV']
         
         def extract_data():
-            data = self.smm.get_variable('emg')
+            data, _ = self.get_data()
+            data = data['emg']
             if len(data) > num_samples:
                 # Only look at the most recent num_samples samples (essentially extracting a single window)
                 data = data[:num_samples]

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -784,7 +784,6 @@ class OnlineDataHandler(DataHandler):
             feature_list = ['MAV']
         
         def extract_data():
-            # data = self.get_data()
             data = self.smm.get_variable('emg')
             if len(data) > num_samples:
                 # Only look at the most recent num_samples samples (essentially extracting a single window)

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -784,10 +784,11 @@ class OnlineDataHandler(DataHandler):
             feature_list = ['MAV']
         
         def extract_data():
-            data = self.get_data()
+            # data = self.get_data()
+            data = self.smm.get_variable('emg')
             if len(data) > num_samples:
                 # Only look at the most recent num_samples samples (essentially extracting a single window)
-                data = data[-num_samples:]
+                data = data[:num_samples]
             # Extract features along each channel
             windows = data[np.newaxis].transpose(0, 2, 1)   # add axis and tranpose to convert to (windows x channels x samples)
             fe = FeatureExtractor()
@@ -796,7 +797,6 @@ class OnlineDataHandler(DataHandler):
                 # Remap raw data to image format
                 for key in feature_set_dict:
                     feature_set_dict[key] = remap_function(feature_set_dict[key]).squeeze() # squeeze to remove extra axis added for windows
-                # data = remap_function(data)
             return feature_set_dict
 
         cmap = cm.viridis   # colourmap to determine heatmap style

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -862,6 +862,7 @@ class OnlineDataHandler(DataHandler):
         normalize: boolean
             Whether the user wants to scale features to zero mean and unit standard deviation before projection (recommended).
         """
+        raise NotImplementedError('This method has not been fixed to account for changes to shared memory.')
         pyplot.style.use('ggplot')
         feature_list = feature_dic.keys()
         fe = FeatureExtractor()

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from glob import glob
 from multiprocessing import Process
 from multiprocessing.managers import BaseManager
-from libemg.utils import make_regex
+from libemg.utils import make_regex, get_windows, _get_fn_windows, _get_mode_windows
 from itertools import compress
 from datetime import datetime
 from multiprocessing import Process, Event

--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -760,7 +760,7 @@ class OnlineDataHandler(DataHandler):
         animation = FuncAnimation(fig, update, interval=100)
         pyplot.show()
     
-    def visualize_heatmap(self, num_samples = 500, feature_list = None, remap_function = None):
+    def visualize_heatmap(self, num_samples = 500, feature_list = None, remap_function = None, cmap = None):
         """Visualize heatmap representation of EMG signals. This is commonly used to represent HD-EMG signals.
 
         Parameters
@@ -774,6 +774,8 @@ class OnlineDataHandler(DataHandler):
         remap_function: callable or None (optional), default=None
             Function pointer that remaps raw data to a format that can be represented by an image (such as np.reshape). Takes in an array and should return
             an array. If None, no remapping is done.
+        cmap: colormap or None (optional), default=None
+            matplotlib colormap used to plot heatmap.
         """
         # Create figure
         pyplot.style.use('ggplot')
@@ -784,6 +786,9 @@ class OnlineDataHandler(DataHandler):
         if feature_list is None:
             # Default to MAV
             feature_list = ['MAV']
+
+        if cmap is None:
+            cmap = cm.viridis   # colourmap to determine heatmap style
         
         def extract_data():
             data, _ = self.get_data()
@@ -817,7 +822,6 @@ class OnlineDataHandler(DataHandler):
                     current_max = max(old_max, feature_data.max())
                     normalization_values[feature] = (current_min, current_max)
 
-        cmap = cm.viridis   # colourmap to determine heatmap style
         
         # Format figure
         sample_data = extract_data()    # access sample data to determine heatmap size

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1129,7 +1129,7 @@ class OnlineEMGRegressor(OnlineStreamer):
                 ax.set_xlabel('Time (s)')
                 ax.set_ylabel('Prediction')
                 for dof_idx in range(len(predictions)):
-                    ax.scatter(timestamps, np.array(decision_horizon_predictions)[:, dof_idx], c=cmap.colors[dof_idx], s=4, alpha=0.8)
+                    ax.scatter(timestamps, np.array(decision_horizon_predictions)[:, dof_idx], color=cmap.colors[dof_idx], s=4, alpha=0.8)
 
                 if legend:
                     ax.legend(handles=handles, loc='upper right')

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1027,7 +1027,7 @@ class OnlineEMGRegressor(OnlineStreamer):
                 ['classifier_input', (100, 1 + 32), np.double], # timestamp <- features ->
             ]
         super(OnlineEMGRegressor, self).__init__(offline_regressor, window_size, window_increment, online_data_handler, file_path,
-                                                 file, smm, smm_items, features, port, ip, std_out, tcp, 'predictions')
+                                                 file, smm, smm_items, features, port, ip, std_out, tcp)
         self.previous_predictions = deque(maxlen=self.predictor.majority_vote)
         self.smi = smm_items
         

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -640,7 +640,7 @@ class OnlineStreamer(ABC):
         self.options['smm'] = smm
         self.options['classifier_smm_writes'] = 0
 
-    def analyze_predictor(self, analyze_time=10, port=12346, ip='127.0.0.1'):
+    def analyze_predictor(self, analyze_time=10):
         """Analyzes the latency of the designed predictor. 
 
         Parameters
@@ -658,7 +658,7 @@ class OnlineStreamer(ABC):
         """
         print("Starting analysis of predictor " + "(" + str(analyze_time) + "s)...")
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
-        sock.bind((ip, port))
+        sock.bind((self.ip, self.port))
         st = time.time()
         times = []
         while(time.time() - st < analyze_time):

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1132,7 +1132,7 @@ class OnlineEMGRegressor(OnlineStreamer):
                     ax.scatter(timestamps, np.array(decision_horizon_predictions)[:, dof_idx], c=cmap.colors[dof_idx], s=4, alpha=0.8)
 
                 if legend:
-                    ax.legend(handles=handles)
+                    ax.legend(handles=handles, loc='upper right')
                 plt.draw()
                 plt.pause(0.01)
             else:

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1126,7 +1126,6 @@ class OnlineEMGRegressor(OnlineStreamer):
 
             if plt.fignum_exists(fig.number):
                 ax.clear()
-                ax.set_ylim((-1.5, 1.5))
                 ax.set_xlabel('Time (s)')
                 ax.set_ylabel('Prediction')
                 for dof_idx in range(len(predictions)):

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -631,7 +631,7 @@ class OnlineStreamer(ABC):
             self.process.start()
     
     def prepare_smm(self):
-        for i in self.smi:
+        for i in self.smm_items:
             if len(i) == 3:
                 i.append(Lock())
         smm = SharedMemoryManager()

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1023,8 +1023,11 @@ class OnlineEMGRegressor(OnlineStreamer):
     tcp: bool (optional), default = False
         If True, will stream predictions over TCP instead of UDP.
     """
-    def __init__(self, offline_regressor, window_size, window_increment, online_data_handler, features, port=12346, ip='127.0.0.1', std_out=False, tcp=False):
-        super(OnlineEMGRegressor, self).__init__(offline_regressor, window_size, window_increment, online_data_handler, features, port, ip, std_out, tcp)
+    def __init__(self, offline_regressor, window_size, window_increment, online_data_handler, features, 
+                 file_path = '.', file = False, smm = True, smm_items = None,
+                 port=12346, ip='127.0.0.1', std_out=False, tcp=False):
+        super(OnlineEMGRegressor, self).__init__(offline_regressor, window_size, window_increment, online_data_handler, file_path,
+                                                 file, smm, smm_items, features, port, ip, std_out, tcp, 'predictions')
         
     def run(self, block=True):
         """Runs the regressor - continuously streams predictions over UDP or TCP.

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1117,7 +1117,6 @@ class OnlineEMGRegressor(OnlineStreamer):
         while True:
             data, _ = sock.recvfrom(1024)
             data = str(data.decode('utf-8'))
-            print(data)
             predictions, timestamp = self.parse_output(data)
             timestamps.append(timestamp - start_time)
             decision_horizon_predictions.append(predictions)

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1024,6 +1024,8 @@ class OnlineEMGRegressor(OnlineStreamer):
             smm_items = [
                 ['model_output', (100, 3), np.double],  # timestamp, prediction 1, prediction 2... (assumes 2 DOFs)
                 ['classifier_input', (100, 1 + 32), np.double], # timestamp <- features ->
+                ["adapt_flag", (1,1), np.int32],
+                ["active_flag", (1,1), np.int8]
             ]
         super(OnlineEMGRegressor, self).__init__(offline_regressor, window_size, window_increment, online_data_handler, file_path,
                                                  file, smm, smm_items, features, port, ip, std_out, tcp)
@@ -1047,9 +1049,7 @@ class OnlineEMGRegressor(OnlineStreamer):
 
     def write_output(self, model_input, window):
         # Make prediction
-        predictions = self.predictor.run(model_input)
-        print(predictions.shape)
-        # might need to convert to 1D
+        predictions = self.predictor.run(model_input).squeeze()
         
         time_stamp = time.time()
         if self.options['std_out']:

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1027,7 +1027,6 @@ class OnlineEMGRegressor(OnlineStreamer):
             ]
         super(OnlineEMGRegressor, self).__init__(offline_regressor, window_size, window_increment, online_data_handler, file_path,
                                                  file, smm, smm_items, features, port, ip, std_out, tcp)
-        self.previous_predictions = deque(maxlen=self.predictor.majority_vote)
         self.smi = smm_items
         
     def run(self, block=True):
@@ -1051,7 +1050,6 @@ class OnlineEMGRegressor(OnlineStreamer):
         predictions = self.predictor.run(model_input)
         print(predictions.shape)
         # might need to convert to 1D
-        self.previous_predictions.append(predictions)
         
         time_stamp = time.time()
         if self.options['std_out']:

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -774,14 +774,15 @@ class OnlineEMGClassifier(OnlineStreamer):
     """
     def __init__(self, offline_classifier, window_size, window_increment, online_data_handler, features, 
                  file_path = '.', file=False, smm=True, 
-                 smm_items=[["classifier_output", (100,4), np.double], #timestamp, class prediction, confidence, velocity
-                      ["classifier_input", (100,1+32), np.double], # timestamp, <- features ->
-                      ["adapt_flag", (1,1), np.int32],
-                      ["active_flag", (1,1), np.int8]],
+                 smm_items= None,
                  port=12346, ip='127.0.0.1', std_out=False, tcp=False,
                  output_format="predictions"):
         
-        
+        if smm_items is None:
+            smm_items = [["classifier_output", (100,4), np.double], #timestamp, class prediction, confidence, velocity
+                        ["classifier_input", (100,1+32), np.double], # timestamp, <- features ->
+                        ["adapt_flag", (1,1), np.int32],
+                        ["active_flag", (1,1), np.int8]]
         super(OnlineEMGClassifier, self).__init__(offline_classifier, window_size, window_increment, online_data_handler, file_path, file, smm, smm_items, features, port, ip, std_out, tcp, output_format)
         self.previous_predictions = deque(maxlen=self.predictor.majority_vote)
         self.smi = smm_items

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -908,15 +908,6 @@ class OnlineEMGClassifier(OnlineStreamer):
             self.conn.sendall(str.encode(message))
 
 
-    def _format_data_sample(self, data):
-        arr = None
-        for feat in data:
-            if arr is None:
-                arr = data[feat]
-            else:
-                arr = np.hstack((arr, data[feat]))
-        return arr
-
     def visualize(self, max_len=50, legend=None):
         """Produces a live plot of classifier decisions -- Note this consumes the decisions.
         Do not use this alongside the actual control operation of libemg. Online classifier has to

--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -665,6 +665,7 @@ class OnlineStreamer(ABC):
             data, _ = sock.recvfrom(1024)
             if data:
                 times.append(time.time())
+        sock.close()
         times = np.diff(times)
         print("Time Between Predictions (Average): " + str(np.mean(times)) + 's')
         print("Time Between Predictions (STD): " + str(np.std(times)) + 's')

--- a/libemg/feature_extractor.py
+++ b/libemg/feature_extractor.py
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 from sklearn.decomposition import PCA, KernelPCA, FastICA
 from sklearn.manifold import TSNE, Isomap
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
-from sklearn.preprocessing import StandardScaler
 from scipy.stats import skew, kurtosis
 from librosa import lpc
 from pywt import wavedec, upcoef
@@ -14,31 +13,7 @@ class FeatureExtractor:
     """
     Feature extraction class including feature groups, feature list, and feature extraction code.
     """
-    def __init__(self, feature_names, feature_dic = None, standardize = False):
-        if isinstance(feature_names, str):
-            # Expects list
-            feature_names = [feature_names]
-
-        if feature_dic is None:
-            feature_dic = {}
-
-        available_feature_groups = list(self.get_feature_groups().keys())
-        feature_list = []
-        for feature_name in feature_names:
-            if feature_name in available_feature_groups:
-                # Passed in feature group - get corresponding list of features
-                feature_name = self.get_feature_groups()[feature_name]
-            else:
-                feature_name = [feature_name]   # cast to list so .extend() appends the item
-            feature_list.extend(feature_name)
-            
-        self.feature_list = feature_list
-        self.feature_dic = feature_dic
-        self.standardize = standardize
-        self.scaler = None
-
-    @staticmethod
-    def get_feature_groups():
+    def get_feature_groups(self):
         """Gets a list of all available feature groups.
         
         Returns
@@ -60,8 +35,7 @@ class FeatureExtractor:
                           }
         return feature_groups
 
-    @staticmethod
-    def get_feature_list():
+    def get_feature_list(self):
         """Gets a list of all available features.
         
         Returns
@@ -132,7 +106,34 @@ class FeatureExtractor:
         projection_list = ['pca', 'kernelpca', 'ica', 'lda', 'tsne', 'isomap']
         return projection_list
 
-    def __call__(self, windows, array=False):
+    def extract_feature_group(self, feature_group, windows, feature_dic={}, array=False):
+        """Extracts a group of features.
+        
+        Parameters
+        ----------
+        feature_group: string
+            The group of features to extract. See the get_feature_list() function for valid options.
+        windows: list 
+            A list of windows - should be computed directly from the OfflineDataHandler or the utils.get_windows() method.
+        feature_dic: dict
+            A dictionary containing the parameters you'd like passed to each feature. ex. {"MDF_sf":1000}
+        array: bool (optional), default=False 
+            If True, the dictionary will get converted to a list. 
+        Returns
+        ----------
+        dictionary or list 
+            A dictionary where each key is a specific feature and its value is a list of the computed 
+            features for each window.
+        """
+        features = {}
+        if not feature_group in self.get_feature_groups():
+            return features
+        feats = self.extract_features(self.get_feature_groups()[feature_group], windows, feature_dic)
+        if array:
+            return self._format_data(feats)
+        return feats 
+
+    def extract_features(self, feature_list, windows, feature_dic={}, array=False):
         """Extracts a list of features.
         
         Parameters
@@ -152,29 +153,15 @@ class FeatureExtractor:
             A dictionary where each key is a specific feature and its value is a list of the computed 
             features for each window.
         """
-        if self.standardize and not array:
-            raise ValueError('Cannot standardize data when it is returned as a dictionary. Please disable standardization or set array=True.')
         features = {}
-        for feature in self.feature_list:
+        for feature in feature_list:
             if feature in self.get_feature_list():
                 method_to_call = getattr(self, 'get' + feature + 'feat')
-                valid_keys = [i for i in list(self.feature_dic.keys()) if feature+"_" in i]
-                smaller_dictionary = dict((k, self.feature_dic[k]) for k in valid_keys if k in self.feature_dic)
+                valid_keys = [i for i in list(feature_dic.keys()) if feature+"_" in i]
+                smaller_dictionary = dict((k, feature_dic[k]) for k in valid_keys if k in feature_dic)
                 features[feature] = method_to_call(windows, **smaller_dictionary)
         if array:
-            features = self._format_data(features)  
-
-        features = self.scale(features)
-        return features
-
-    def scale(self, features):
-        if self.standardize:
-            if self.scaler is None:
-                # Fit scaler
-                self.scaler = StandardScaler()
-                self.scaler.fit(features)
-            features = self.scaler.transform(features)
-
+            return self._format_data(features)  
         return features
 
     def check_features(self, features, silent=False):


### PR DESCRIPTION
Recent shared memory changes only included changes to `OnlineEMGClassifier` and not `OnlineEMGRegressor`. This meant that online regression wasn't functional. Main changes include:

- [x] Modified data parsing and output methods to grab from shared memory instead of from a streamer socket.
- [x] Centralized repeated code between classification and regression into `OnlineStreamer`.
- [x] Finalize interface/use case for shared memory items.
- [ ] Fix online visualization lag (submitting bug report instead due to time).


Closes #38.