### PR TITLE
Rename ColumnFetch to ColumnFetcher

### DIFF
--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -181,7 +181,7 @@ class FilePackager(MetadataFetcher):
         return packaged_file_data
 
 
-class ColumnFetch(MetadataFetcher):
+class ColumnFetcher(MetadataFetcher):
     def __init__(self, description: str, column_mask: Sequence[int] | int, values: Sequence | None = None):
         """Fetch metadata from columns within data file.
 

--- a/libemg/datasets.py
+++ b/libemg/datasets.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import zipfile
 import scipy.io as sio
-from libemg.data_handler import ColumnFetch, MetadataFetcher, OfflineDataHandler, RegexFilter, FilePackager
+from libemg.data_handler import ColumnFetcher, MetadataFetcher, OfflineDataHandler, RegexFilter, FilePackager
 from libemg.utils import make_regex
 from glob import glob
 from os import walk
@@ -243,7 +243,7 @@ class _SessionFetcher(MetadataFetcher):
         return session_idx * np.ones((file_data.shape[0], 1), dtype=int)
 
 
-class _RepFetcher(ColumnFetch):
+class _RepFetcher(ColumnFetcher):
     def __call__(self, filename, file_data, all_files):
         column_data = super().__call__(filename, file_data, all_files)
         
@@ -318,7 +318,7 @@ class PutEMGForceDataset(Dataset):
             ]
             metadata_fetchers = [
                 _SessionFetcher(),
-                ColumnFetch('labels', column_mask),
+                ColumnFetcher('labels', column_mask),
                 _RepFetcher('reps', list(range(36, 40)))
             ]
             odh = OfflineDataHandler()


### PR DESCRIPTION
Class name was accidentally changed during a previous commit.

Reverted so its name is more consistent with other classes. Closes #60.