### PR TITLE
ninapro db2 dataglove support added

### DIFF
--- a/libemg/filtering.py
+++ b/libemg/filtering.py
@@ -123,7 +123,7 @@ class Filter:
         '''
         assert hasattr(data,"data")
         for f in range(len(data.data)):
-            data.data[f] = self._run_filter(data.data[f])
+            data.data[f] = self._run_filter(data.data[f], data.dataglove)
 
     def _filter_np_ndarray(self, data):
         ''' Helper function that runs the installed filters on an np.ndarray.
@@ -140,7 +140,7 @@ class Filter:
         '''
         return self._run_filter(data)
 
-    def _run_filter(self, matrix):
+    def _run_filter(self, matrix, dataglove=False):
         ''' Helper function that actually runs the installed filters on an np.ndarray. This is where the actual processing happens.
 
         Parameters
@@ -153,6 +153,10 @@ class Filter:
         matrix: np.ndarray
             Data that has been filtered.
         '''
+
+        if dataglove:
+            matrix = matrix[:, :-dataglove]
+
         for fl in range(len(self.filters)):
             if self.filters[fl]["name"] == "standardize":
                 matrix = (matrix - self.filters[fl]["mean"]) / self.filters[fl]["std"]


### PR DESCRIPTION
Ninapro DB2 dataglove support added. Dataglove flag added to the relevant methods, default is False so legacy examples should work. Filtering also modified to work with the ODH that include dataglove (it excludes regression targets), Feature extraction should not be affected since it works on windows (after calling parse_windows), and dataglove (regression targets) are outputed as seperate (if dataglove flag is True in NinaproDB2 class).
Also added logging for prepare_data and parse_windows since it takes quite time for low windows increments. While converting Mat to CSV, it automatically downsamples to 1KHz from 2 KHz,, added option to avoid it (default is as it was in the original code).
preferably pull to a new branch, since DB8 needs to be added as well.