### PR TITLE
Online Regressor Visualization Lag

### DIFF
--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -1152,6 +1152,17 @@ class OnlineEMGRegressor(OnlineStreamer):
             self.conn.sendall(str.encode(message))
 
     def visualize(self, max_len = 50, legend = False):
+        """Plot a live visualization of the online regressor's predictions. Please note that the animation updates every 5 milliseconds,
+        so keep this in mind when choosing window size and increment. For example, a window increment that's too small may cause delay in the plotting
+        if the regressor is making predictions faster than the plot can be updated.
+
+        Parameters
+        ----------
+        max_len: int (optional), default = 50
+            Maximum number of predictions to plot at a time. Defaults to 50.
+        legend: bool (optional), default = False
+            True if a legend should be shown, otherwise False. Defaults to False.
+        """
         plt.style.use('ggplot')
         fig, ax = plt.subplots(layout='constrained')
         fig.suptitle('Live Regressor Output', fontsize=16)


### PR DESCRIPTION
The online regressor's `visualize()` method had some lag when plotting.

Improved this by using the `matplotlib` animation functionality. You may still see lag if that window parameters aren't set properly (e.g., window increment too small), but there isn't anything we can do about that. I added a note about this in the docstring.

Closes #51.