### PR TITLE
Handle SGT Streaming Interruption

### DIFF
--- a/libemg/_gui/_data_collection_panel.py
+++ b/libemg/_gui/_data_collection_panel.py
@@ -286,6 +286,8 @@ class DataCollectionPanel:
         for mod in self.rep_buffer:
             filename = file_parts[0] + "_" + mod + "." + file_parts[1]
             data = np.vstack(self.rep_buffer[mod])[::-1,:]
+            if data.size == 0:
+                raise ConnectionError('Attempting to store data, but received 0 samples during repetition, suggesting that the data stream from the device has been interrupted. Please check the device connection and verify that previous files are not missing samples.')
             with open(filename, "w", newline='', encoding='utf-8') as file:
                 writer = csv.writer(file)
                 for row in data:


### PR DESCRIPTION
SGT continued prompting for reps even if the data stream was interrupted, which will likely cause users to waste time collecting reps when data aren't streaming.

Added a check that we actually got samples when saving data. If the array is empty, we throw a `ConnectionError`.