### PR TITLE
SocketController Shared Memory

### DIFF
--- a/libemg/animator.py
+++ b/libemg/animator.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import os
 from typing import Callable, Sequence
 import warnings
@@ -340,8 +341,8 @@ class PlotAnimator(Animator):
         """
         if save_coordinates:
             # Save coordinates in .txt file
-            filename_no_extension = os.path.splitext(self.output_filepath)[0]
-            labels_filepath = filename_no_extension + '.txt'
+            labels_filepath = Path(self.output_filepath).with_suffix('.txt')
+            labels_filepath.parent.mkdir(parents=True, exist_ok=True)
             np.savetxt(labels_filepath, coordinates, delimiter=',')
         
         # Format figure

--- a/libemg/environments/controllers.py
+++ b/libemg/environments/controllers.py
@@ -167,6 +167,11 @@ class SocketController(Controller):
             if data:
                 # Data received
                 self.action.value = message
+
+    def terminate(self) -> None:
+        # Add some cleanup
+        self.sock.close()
+        super().terminate()
     
 
 class ClassifierController(SocketController):

--- a/libemg/shared_memory_manager.py
+++ b/libemg/shared_memory_manager.py
@@ -15,7 +15,13 @@ class SharedMemoryManager:
         except:
             pass
         
-        smh = SharedMemory(tag, create=True, size=int(type().itemsize * np.prod(shape)))
+        try:
+            type_size = type().itemsize
+        except TypeError:
+            # Passed in non-callable dtype
+            type_size = type.itemsize
+
+        smh = SharedMemory(tag, create=True, size=int(type_size * np.prod(shape)))
         data = np.ndarray((shape),dtype=type,buffer=smh.buf)
         data.fill(0)
         self.variables[tag] = {}
@@ -28,7 +34,12 @@ class SharedMemoryManager:
 
     def find_variable(self, tag, shape, type, lock):
         try:
-            smh = SharedMemory(tag, size=int(type().itemsize * np.prod(shape)))
+            type_size = type().itemsize
+        except TypeError:
+            # Passed in non-callable dtype
+            type_size = type.itemsize
+        try:
+            smh = SharedMemory(tag, size=int(type_size * np.prod(shape)))
             # create a new numpy array that uses the shared memory
             data = np.ndarray((shape), dtype=type, buffer=smh.buf)
             self.variables[tag] = {}
@@ -41,7 +52,6 @@ class SharedMemoryManager:
         except FileNotFoundError:
             return False
         
-
     def get_variable(self, tag):
         assert tag in self.variables.keys()
         with self.variables[tag]["lock"]:
@@ -51,7 +61,6 @@ class SharedMemoryManager:
         assert tag in self.variables.keys()
         with self.variables[tag]["lock"]:
             self.variables[tag]["data"][:] = fn(self.variables[tag]["data"])
-
 
     def cleanup(self, parent = True):
         for k in self.variables.keys():


### PR DESCRIPTION
Related to #90, the `SocketController` used a `multiprocessing.Manager` instead of `SharedMemory`, which made it (slightly) slower and (more importantly) used a different low level interface than other parts of `libemg` (e.g., streamers).

Replaced the `multiprocessing.Manager` with a `SharedMemoryManager`.