### PR TITLE
Fix `visualize_heatmap` Throwing Error for Feature Lists of Length 1

### DIFF
--- a/libemg/data_handler.py
+++ b/libemg/data_handler.py
@@ -5,16 +5,13 @@ import numpy.typing as npt
 import pandas as pd
 import os
 import re
-import socket
-import csv
-import pickle
 import time
 import math
 import wfdb
 import copy
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
-from sklearn.decomposition import PCA
+from matplotlib.axes import Axes
 from scipy.ndimage import zoom
 from scipy.signal import decimate
 from matplotlib import pyplot
@@ -836,6 +833,8 @@ class OnlineDataHandler(DataHandler):
         # Format figure
         sample_data = extract_data()    # access sample data to determine heatmap size
         fig, axs = plt.subplots(len(sample_data.keys()), 1)
+        if isinstance(axs, Axes):
+            axs = np.array([axs])
         fig.suptitle(f'HD-EMG Heatmap')
         plots = []
         for (feature_key, feature_data), ax in zip(sample_data.items(), axs):


### PR DESCRIPTION
`visualize_heatmap` can now handle feature lists of any length.

Closes #102.