### PR TITLE
Online `visualize()` Bug Fix

### DIFF
--- a/libemg/emg_predictor.py
+++ b/libemg/emg_predictor.py
@@ -986,7 +986,6 @@ class OnlineEMGClassifier(OnlineStreamer):
         cmap = cm.get_cmap('turbo', num_classes)
 
         controller = ClassifierController(output_format=self.output_format, num_classes=num_classes, ip=self.ip, port=self.port)
-        controller.start()
 
         if legend is not None:
             for i in range(num_classes):
@@ -1173,7 +1172,6 @@ class OnlineEMGRegressor(OnlineStreamer):
         ax.set_ylabel('Prediction')
 
         controller = RegressorController(ip=self.ip, port=self.port)
-        controller.start()
 
         # Wait for controller to start receiving data
         predictions = None


### PR DESCRIPTION
Online `visualize` methods had an old method call that no longer exists. 

Removed old calls to Controller.start.