### PR TITLE
Connect to specific myo armband via MAC address

### DIFF
--- a/libemg/_streamers/_myo_streamer.py
+++ b/libemg/_streamers/_myo_streamer.py
@@ -516,7 +516,7 @@ class Myo(object):
 import numpy as np
 from multiprocessing import Process, Event
 class MyoStreamer(Process):
-	def __init__(self, filtered, emg, imu, shared_memory_items=[]):
+	def __init__(self, filtered, emg, imu, shared_memory_items=[], addr=None):
 		Process.__init__(self, daemon=True)
 		self.filtered = filtered
 		self.emg = emg
@@ -524,6 +524,7 @@ class MyoStreamer(Process):
 		self.smm = SharedMemoryManager()
 		self.shared_memory_items = shared_memory_items
 		self.signal = Event()
+		self.addr = addr
 
 	def run(self):
 		for item in self.shared_memory_items:
@@ -533,7 +534,7 @@ class MyoStreamer(Process):
 		if not self.filtered:
 			mode = emg_mode.RAW
 		self.m = Myo(mode=mode)
-		self.m.connect()
+		self.m.connect(addr=self.addr)
 
 		if self.emg:
 			def write_emg(emg):

--- a/libemg/streamers.py
+++ b/libemg/streamers.py
@@ -248,7 +248,8 @@ def myo_streamer(
     shared_memory_items : list | None = None,
     emg                 : bool = True, 
     imu                 : bool = False,
-    filtered            : bool=True):
+    filtered            : bool=True,
+    addr                : list | None = None):
     """The streamer for the myo armband. 
 
     This function connects to the Myo. It leverages the PyoMyo 
@@ -265,6 +266,9 @@ def myo_streamer(
         Specifies whether IMU data should be forwarded to shared memory.
     filtered : bool (optional), default=True
         If True, the data is the filtered data. Otherwise it is the raw unfiltered data.
+    addr : list (optional)
+        The MAC address of the Myo armband to connect to. Addr is the MAC address in format: [93, 41, 55, 245, 82, 194]
+        If None, it will connect to the first Myo it finds.
     Returns
     ----------
     Object: streamer
@@ -286,7 +290,7 @@ def myo_streamer(
 
     for item in shared_memory_items:
         item.append(Lock())
-    myo = MyoStreamer(filtered, emg, imu, shared_memory_items)
+    myo = MyoStreamer(filtered, emg, imu, shared_memory_items, addr)
     myo.start()
     return myo, shared_memory_items
 


### PR DESCRIPTION
This pull request adds support for explicitly specifying a Myo armband’s MAC address when using the libemg myo_streamer API. Under the hood, libemg relies on pyomyo to discover and connect to nearby Myo devices; previously it would always connect to the first available armband. With this change, users can now pass an optional addr argument.
**Behavior:**
- If addr is provided, it is forwarded directly to pyomyo to target the specified device.
- If omitted (or None), the existing auto-discover behavior remains unchanged.

**Example Usage:**
`self.streamer, self.shared_memory = myo_streamer(addr=[53, 166, 29, 26, 218, 223])`


