### PR TITLE
EMG Streaming Pipeline for OTB MuoviPlus

### DIFF
--- a/docs/source/documentation/supported_hardware/supported_hardware_doc.md
+++ b/docs/source/documentation/supported_hardware/supported_hardware_doc.md
@@ -23,21 +23,23 @@ By default, LibEMG supports several hardware devices (shown in Table 1).
 - The [**Delsys**](https://delsys.com/) is a commercially available system primarily used for medical applications due to its relatively high cost. 
 - The [**SIFI Cuff**](https://sifilabs.com/) is a pre-released device that will soon be commercially available. Compared to the Myo armband, this device has a much higher sampling rate (~2000 Hz).
 - The [**Oymotion Cuff**](http://www.oymotion.com/en/product32/149) is a commercial device that samples EMG at 1000 Hz (8 bits) or 500 Hz (12 bits). 
-<!-- - The [**OTBioelettronica**](https://otbioelettronica.it/hardware/) devices are a set of commercially available HDEMG systems. -->
 - The [**MindRove Armband**](https://mindrove.com/armband/) is a commercial device that samples 8-channel EMG at 500 Hz (24 bit) and IMU at 50 Hz. Data are streamed over a Wifi connection.
+- The [**OTB Muovi+**](https://otbioelettronica.it/en/muoviplus/) is part of the OTBioelettronica hardware family and supports High Density EMG (HDEMG). 
+<!-- - The [**OTBioelettronica**](https://otbioelettronica.it/hardware/) devices are a set of commercially available HDEMG systems. -->
 
 
 If selecting EMG hardware for real-time use, wireless armbands that sample above 500 Hz are preferred. Additionally, future iterations of LibEMG will include Inertial Measurement Unit (IMU) support. As such, devices should have IMUs to enable more interaction opportunities.
 
-| <center>Hardware</center> | <center>Function</center> | <center>Image</center> |
-| ------------- | ------------- | ------------- |
-| Myo Armband  | `myo_streamer()`  | <div class="device_img">![](devices/Myo.png) </div>|
-| Delsys  | `delsys_streamer()` or `delsys_API_streamer()` | <div class="device_img_2">![](devices/delsys_trigno.png) </div>|
-| SIFI Cuff | `sifi_streamer()` | <div class="device_img">![](devices/sifi_cuff.png) </div>|
-| Oymotion | `oymotion_streamer()`| <div class="device_img">![](devices/oymotion.png) </div>|
-| MindRove Armband | `mindrove_streamer()`| <div class="device_img">![](devices/mindrove.png) </div>|
+| <center>Hardware</center> | <center>Function</center>                      | <center>Image</center>                                          |
+| ------------------------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| Myo Armband               | `myo_streamer()`                               | <div class="device_img">![](devices/Myo.png) </div>             |
+| Delsys                    | `delsys_streamer()` or `delsys_API_streamer()` | <div class="device_img_2">![](devices/delsys_trigno.png) </div> |
+| SIFI Cuff                 | `sifi_streamer()`                              | <div class="device_img">![](devices/sifi_cuff.png) </div>       |
+| Oymotion                  | `oymotion_streamer()`                          | <div class="device_img">![](devices/oymotion.png) </div>        |
+| MindRove Armband          | `mindrove_streamer()`                          | <div class="device_img">![](devices/mindrove.png) </div>        |
+| Muovi+                    | `otb_muovi_plus_streamer()`                    | <div class="device_img">![](devices/muovi+.png) </div>          |
+
 <!-- | Muovi | `otb_muovi_streamer()`| <div class="device_img">![](devices/muovi.png) </div>| 
-| Muovi+ | `otb_muovi_plus_streamer()`| <div class="device_img">![](devices/muovi+.png) </div>| 
 | Sessantaquattro+ | `otb_sessantaquattro_plus_streamer()`| <div class="device_img">![](devices/sess.png) </div>|  -->
 
 <center> <p>Table 1: The list of all implemented streamers.</p> </center>

--- a/libemg/streamers.py
+++ b/libemg/streamers.py
@@ -16,6 +16,7 @@ from libemg._streamers._emager_streamer import EmagerStreamer
 from libemg._streamers._sifi_bridge_streamer import SiFiBridgeStreamer
 from libemg._streamers._leap_streamer import LeapStreamer
 from libemg._streamers._mindrove import MindroveStreamer
+from libemg._streamers._OTB_MuoviPlus import OTBMuoviPlusEMGStreamer
 
 def sifi_biopoint_streamer(
     name = "BioPoint_v1_3",
@@ -683,3 +684,49 @@ def mindrove_streamer(shared_memory_items = None):
     m.start()
     return m, shared_memory_items
 
+
+def otb_muovi_plus_streamer(shared_memory_items = None,
+                            ip: str = '0.0.0.0',
+                            port: int = 54321,
+                            emg_channels: int = 128):
+    """The streamer for the OTB Muovi+ device.
+    
+    This function connects to the OTB Muovi+ device and streams its data over a network socket  and access it via shared memory.
+
+    Parameters
+    ----------
+    shared_memory_items : list (optional)
+        Shared memory configuration parameters for the streamer in format:
+        ["tag", (size), datatype].
+
+    
+    ip : str (optional), default='0.0.0.0'
+        The IP address of the OTB Muovi+ device. Used to connect to the device.
+    port : int (optional), default=54321
+        The port number to connect to the OTB Muovi+ device.
+    emg_channels : int (optional), default=128
+        The number of EMG channels to stream from the OTB Muovi+ device. 
+        This should match the number of channels configured on the device.
+    Returns
+    ----------
+    Object: streamer
+        The OTB Muovi+ streamer object.
+    Object: shared memory
+        The shared memory object.
+    Examples
+    ---------
+    >>> streamer, shared_memory = otb_muovi_plus_streamer(ip='192.168.76.1', port=54320)
+    """
+    if shared_memory_items is None:
+        shared_memory_items = [
+            ["emg",       (2000, emg_channels), np.double],
+            ["emg_count", (1,1),    np.int32]
+        ]
+
+    for item in shared_memory_items:
+        item.append(Lock())
+
+    muoviplus = OTBMuoviPlusEMGStreamer(ip=ip, port=port, shared_memory_items=shared_memory_items, emg_channels=emg_channels)
+    muoviplus.start()
+
+    return muoviplus, shared_memory_items


### PR DESCRIPTION
## Summary

This pull request adds a new implementation for real-time EMG data streaming from the **OTB MuoviPlus** device. It handles TCP communication, parses binary EMG data packets, and writes results to shared memory for use in downstream processing pipelines.

---

## What's New

### Core Components

- **`OTBMuoviPlusEMGStreamer`**
  - Connects to MuoviPlus device via TCP.
  - Sends device-specific start/stop control signals.
  - Receives and buffers EMG data using the shared memory manager.
  - Supports both **64** and **128** channel configurations.

- **`PacketParser`**
  - Converts raw binary packets to signed 16-bit integers.
  - Organizes interleaved samples into usable channel arrays.

- **Shared Memory Integration**
  - Uses `SharedMemoryManager` to hold:
    - Rolling EMG buffer.
    - Sample count tracker.

---

## Features

-  Real-time TCP streaming from OTB MuoviPlus.
-  Automatic parsing and structuring of EMG data.
-  Supports dynamic channel trimming for 64-channel probes.
-  Graceful handling of termination signals (`SIGINT`, `atexit`).

---

### Added
- Initial EMG streaming module for OTB MuoviPlus device.
- Packet parsing logic with support for 64/128 EMG channels.
- Shared memory interface for real-time access to EMG data.
- Graceful signal handling and cleanup.

## Usage Example

```python
from libemg.streamers import otb_muovi_plus_streamer

streamer, shared_memory = otb_muovi_plus_streamer(ip="192.168.76.1", port=54320, emg_channels=128)

