### PR TITLE
2 Minor changes

### DIFF
--- a/libemg/_datasets/emg_epn612.py
+++ b/libemg/_datasets/emg_epn612.py
@@ -102,6 +102,8 @@ class EMGEPN_UserDependent(EMGEPN612):
 
         if split:
             data = {'All': odh, 'Train': odh_tr, 'Test': odh_te}
+        else:
+            data = odh_tr + odh_te
         return data
     
 class EMGEPN_UserIndependent(EMGEPN612):
@@ -112,8 +114,11 @@ class EMGEPN_UserIndependent(EMGEPN612):
         odh = self.get_odh(subjects, feature_list, window_size, window_inc, feature_dic)
         odh_tr = odh.isolate_data('subjects', values=list(range(0,306)))
         odh_te = odh.isolate_data('subjects', values=list(range(306,612)))
+        
         if split:
             data = {'All': odh_tr + odh_te, 'Train': odh_tr, 'Test': odh_te}
+        else:
+            data = odh_tr + odh_te
         return data
 
         


### PR DESCRIPTION
1. Commit [Will fail if split==False](https://github.com/LibEMG/libemg/commit/251fe22b98867cae7c1c671e775ff1a25f0cf2f3) is only a minor bug fix for EPN612, that will raise error if `split=False` when calling.

2. Commit [Faster windowing](https://github.com/LibEMG/libemg/commit/48c9e2fbcff1fe1902ea14c44a45ace6740e31b1) is just a suggestion, no bug. 
For this code for instance: 
```python
import time
from libemg.datasets import get_dataset_list
emg_epn612 = get_dataset_list(cross_user=True)['EMGEPN612']()
dataset = emg_epn612.prepare_data()['All']
t = time.time()
windows, meta = dataset.parse_windows(7, 3)
print(time.time() - t)
windows.shape
```
The output for the old parser was 
```
122.64114379882812
(17324564, 8, 7)
```
For the new one:
```
91.87159585952759
(17324564, 8, 7)
```
Mathmatically equilivant, but faster. But this isn't a bug, just improvements.